### PR TITLE
fix issue #1

### DIFF
--- a/service/service_test.go
+++ b/service/service_test.go
@@ -196,6 +196,109 @@ func Test_GetTables(t *testing.T) {
 				},
 			},
 		},
+		{
+			&pb.GetTablesRequest{
+				Page: "issue_1",
+				N:    []string{},
+			},
+			&pb.GetTablesResponse{
+				Tables: []*pb.Table{
+					{
+						Rows: map[int64]*pb.Row{
+							0: {
+								Columns: map[int64]string{
+									0: "Language",
+									1: "Country",
+									2: "Status",
+								},
+							},
+							1: {
+								Columns: map[int64]string{
+									0: "Korean",
+									1: "Australia",
+									2: "minority",
+								},
+							},
+							2: {
+								Columns: map[int64]string{
+									0: "Korean",
+									1: "Brazil",
+									2: "minority",
+								},
+							},
+							3: {
+								Columns: map[int64]string{
+									0: "Korean",
+									1: "Canada",
+									2: "minority",
+								},
+							},
+							4: {
+								Columns: map[int64]string{
+									0: "Korean",
+									1: "China",
+									2: "minority, co-official with Chinese in Yanbian Korean Autonomous Prefecture in Jilin Province",
+								},
+							},
+							5: {
+								Columns: map[int64]string{
+									0: "Korean",
+									1: "Japan",
+									2: "minority",
+								},
+							},
+							6: {
+								Columns: map[int64]string{
+									0: "Korean",
+									1: "North Korea",
+									2: "official",
+								},
+							},
+							7: {
+								Columns: map[int64]string{
+									0: "Korean",
+									1: "Philippines",
+									2: "minority",
+								},
+							},
+							8: {
+								Columns: map[int64]string{
+									0: "Korean",
+									1: "South Korea",
+									2: "official",
+								},
+							},
+							9: {
+								Columns: map[int64]string{
+									0: "Korean",
+									1: "Taiwan",
+									2: "minority",
+								},
+							},
+							10: {
+								Columns: map[int64]string{
+									0: "Korean",
+									1: "United States",
+									2: "minority",
+								},
+							},
+							11: {
+								Columns: map[int64]string{
+									0: "Jeju",
+									1: "South Korea",
+									2: "official, in Jeju Island",
+								},
+							},
+							12: {
+								Columns: map[int64]string{
+									0: "Jeju",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	svc := &Service{}
@@ -261,6 +364,13 @@ func startMocks() {
 		func(*http.Request) (*http.Response, error) {
 			return &http.Response{
 				Body: getRespBody("table1.html"),
+			}, nil
+		})
+
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://en.%s/%s", baseURL, "issue_1"),
+		func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				Body: getRespBody("issue_1.html"),
 			}, nil
 		})
 

--- a/service/testdata/issue_1.html
+++ b/service/testdata/issue_1.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html>
+   <body>
+      <table class="wikitable">
+         <tbody>
+            <tr>
+               <th width="120px">Language</th>
+               <th width="200px">Country</th>
+               <th>Status
+               </th>
+            </tr>
+            <tr>
+               <td rowspan="10"><a href="/wiki/Korean_language" title="Korean language">Korean</a>
+               </td>
+               <td><span class="datasortkey" data-sort-value="Australia"><span class="flagicon"><img alt="" src="//upload.wikimedia.org/wikipedia/commons/thumb/8/88/Flag_of_Australia_%28converted%29.svg/23px-Flag_of_Australia_%28converted%29.svg.png" decoding="async" width="23" height="12" class="thumbborder" srcset="//upload.wikimedia.org/wikipedia/commons/thumb/8/88/Flag_of_Australia_%28converted%29.svg/35px-Flag_of_Australia_%28converted%29.svg.png 1.5x, //upload.wikimedia.org/wikipedia/commons/thumb/8/88/Flag_of_Australia_%28converted%29.svg/46px-Flag_of_Australia_%28converted%29.svg.png 2x" data-file-width="1280" data-file-height="640">&nbsp;</span><a href="/wiki/Australia" title="Australia">Australia</a></span></td>
+               <td>minority
+               </td>
+            </tr>
+            <tr>
+               <td><span class="datasortkey" data-sort-value="Brazil"><span class="flagicon"><img alt="" src="//upload.wikimedia.org/wikipedia/en/thumb/0/05/Flag_of_Brazil.svg/22px-Flag_of_Brazil.svg.png" decoding="async" width="22" height="15" class="thumbborder" srcset="//upload.wikimedia.org/wikipedia/en/thumb/0/05/Flag_of_Brazil.svg/33px-Flag_of_Brazil.svg.png 1.5x, //upload.wikimedia.org/wikipedia/en/thumb/0/05/Flag_of_Brazil.svg/43px-Flag_of_Brazil.svg.png 2x" data-file-width="720" data-file-height="504">&nbsp;</span><a href="/wiki/Brazil" title="Brazil">Brazil</a></span></td>
+               <td>minority
+               </td>
+            </tr>
+            <tr>
+               <td><span class="datasortkey" data-sort-value="Canada"><span class="flagicon"><img alt="" src="//upload.wikimedia.org/wikipedia/commons/thumb/d/d9/Flag_of_Canada_%28Pantone%29.svg/23px-Flag_of_Canada_%28Pantone%29.svg.png" decoding="async" width="23" height="12" class="thumbborder" srcset="//upload.wikimedia.org/wikipedia/commons/thumb/d/d9/Flag_of_Canada_%28Pantone%29.svg/35px-Flag_of_Canada_%28Pantone%29.svg.png 1.5x, //upload.wikimedia.org/wikipedia/commons/thumb/d/d9/Flag_of_Canada_%28Pantone%29.svg/46px-Flag_of_Canada_%28Pantone%29.svg.png 2x" data-file-width="1200" data-file-height="600">&nbsp;</span><a href="/wiki/Canada" title="Canada">Canada</a></span></td>
+               <td>minority
+               </td>
+            </tr>
+            <tr>
+               <td><span class="datasortkey" data-sort-value="China"><span class="flagicon"><img alt="" src="//upload.wikimedia.org/wikipedia/commons/thumb/f/fa/Flag_of_the_People%27s_Republic_of_China.svg/23px-Flag_of_the_People%27s_Republic_of_China.svg.png" decoding="async" width="23" height="15" class="thumbborder" srcset="//upload.wikimedia.org/wikipedia/commons/thumb/f/fa/Flag_of_the_People%27s_Republic_of_China.svg/35px-Flag_of_the_People%27s_Republic_of_China.svg.png 1.5x, //upload.wikimedia.org/wikipedia/commons/thumb/f/fa/Flag_of_the_People%27s_Republic_of_China.svg/45px-Flag_of_the_People%27s_Republic_of_China.svg.png 2x" data-file-width="900" data-file-height="600">&nbsp;</span><a href="/wiki/China" title="China">China</a></span></td>
+               <td>minority, co-official with <a href="/wiki/Chinese_language" title="Chinese language">Chinese</a> in <a href="/wiki/Yanbian_Korean_Autonomous_Prefecture" title="Yanbian Korean Autonomous Prefecture">Yanbian Korean Autonomous Prefecture</a> in <a href="/wiki/Jilin" title="Jilin">Jilin</a> Province
+               </td>
+            </tr>
+            <tr>
+               <td><span class="datasortkey" data-sort-value="Japan"><span class="flagicon"><img alt="" src="//upload.wikimedia.org/wikipedia/en/thumb/9/9e/Flag_of_Japan.svg/23px-Flag_of_Japan.svg.png" decoding="async" width="23" height="15" class="thumbborder" srcset="//upload.wikimedia.org/wikipedia/en/thumb/9/9e/Flag_of_Japan.svg/35px-Flag_of_Japan.svg.png 1.5x, //upload.wikimedia.org/wikipedia/en/thumb/9/9e/Flag_of_Japan.svg/45px-Flag_of_Japan.svg.png 2x" data-file-width="900" data-file-height="600">&nbsp;</span><a href="/wiki/Japan" title="Japan">Japan</a></span></td>
+               <td>minority
+               </td>
+            </tr>
+            <tr>
+               <td><span class="datasortkey" data-sort-value="North Korea"><span class="flagicon"><img alt="" src="//upload.wikimedia.org/wikipedia/commons/thumb/5/51/Flag_of_North_Korea.svg/23px-Flag_of_North_Korea.svg.png" decoding="async" width="23" height="12" class="thumbborder" srcset="//upload.wikimedia.org/wikipedia/commons/thumb/5/51/Flag_of_North_Korea.svg/35px-Flag_of_North_Korea.svg.png 1.5x, //upload.wikimedia.org/wikipedia/commons/thumb/5/51/Flag_of_North_Korea.svg/46px-Flag_of_North_Korea.svg.png 2x" data-file-width="1600" data-file-height="800">&nbsp;</span><a href="/wiki/North_Korea" title="North Korea">North Korea</a></span></td>
+               <td>official
+               </td>
+            </tr>
+            <tr>
+               <td><span class="datasortkey" data-sort-value="Philippines"><span class="flagicon"><img alt="" src="//upload.wikimedia.org/wikipedia/commons/thumb/9/99/Flag_of_the_Philippines.svg/23px-Flag_of_the_Philippines.svg.png" decoding="async" width="23" height="12" class="thumbborder" srcset="//upload.wikimedia.org/wikipedia/commons/thumb/9/99/Flag_of_the_Philippines.svg/35px-Flag_of_the_Philippines.svg.png 1.5x, //upload.wikimedia.org/wikipedia/commons/thumb/9/99/Flag_of_the_Philippines.svg/46px-Flag_of_the_Philippines.svg.png 2x" data-file-width="1200" data-file-height="600">&nbsp;</span><a href="/wiki/Philippines" title="Philippines">Philippines</a></span></td>
+               <td>minority
+               </td>
+            </tr>
+            <tr>
+               <td><span class="datasortkey" data-sort-value="South Korea"><span class="flagicon"><img alt="" src="//upload.wikimedia.org/wikipedia/commons/thumb/0/09/Flag_of_South_Korea.svg/23px-Flag_of_South_Korea.svg.png" decoding="async" width="23" height="15" class="thumbborder" srcset="//upload.wikimedia.org/wikipedia/commons/thumb/0/09/Flag_of_South_Korea.svg/35px-Flag_of_South_Korea.svg.png 1.5x, //upload.wikimedia.org/wikipedia/commons/thumb/0/09/Flag_of_South_Korea.svg/45px-Flag_of_South_Korea.svg.png 2x" data-file-width="900" data-file-height="600">&nbsp;</span><a href="/wiki/South_Korea" title="South Korea">South Korea</a></span></td>
+               <td>official
+               </td>
+            </tr>
+            <tr>
+               <td><span class="datasortkey" data-sort-value="Taiwan"><span class="flagicon"><img alt="" src="//upload.wikimedia.org/wikipedia/commons/thumb/7/72/Flag_of_the_Republic_of_China.svg/23px-Flag_of_the_Republic_of_China.svg.png" decoding="async" width="23" height="15" class="thumbborder" srcset="//upload.wikimedia.org/wikipedia/commons/thumb/7/72/Flag_of_the_Republic_of_China.svg/35px-Flag_of_the_Republic_of_China.svg.png 1.5x, //upload.wikimedia.org/wikipedia/commons/thumb/7/72/Flag_of_the_Republic_of_China.svg/45px-Flag_of_the_Republic_of_China.svg.png 2x" data-file-width="900" data-file-height="600">&nbsp;</span><a href="/wiki/Taiwan" title="Taiwan">Taiwan</a></span></td>
+               <td>minority
+               </td>
+            </tr>
+            <tr>
+               <td><span class="datasortkey" data-sort-value="United States"><span class="flagicon"><img alt="" src="//upload.wikimedia.org/wikipedia/en/thumb/a/a4/Flag_of_the_United_States.svg/23px-Flag_of_the_United_States.svg.png" decoding="async" width="23" height="12" class="thumbborder" srcset="//upload.wikimedia.org/wikipedia/en/thumb/a/a4/Flag_of_the_United_States.svg/35px-Flag_of_the_United_States.svg.png 1.5x, //upload.wikimedia.org/wikipedia/en/thumb/a/a4/Flag_of_the_United_States.svg/46px-Flag_of_the_United_States.svg.png 2x" data-file-width="1235" data-file-height="650">&nbsp;</span><a href="/wiki/United_States" title="United States">United States</a></span></td>
+               <td>minority
+               </td>
+            </tr>
+            <tr>
+               <td rowspan="2"><a href="/wiki/Jeju_language" title="Jeju language">Jeju</a>
+               </td>
+               <td><span class="datasortkey" data-sort-value="South Korea"><span class="flagicon"><img alt="" src="//upload.wikimedia.org/wikipedia/commons/thumb/0/09/Flag_of_South_Korea.svg/23px-Flag_of_South_Korea.svg.png" decoding="async" width="23" height="15" class="thumbborder" srcset="//upload.wikimedia.org/wikipedia/commons/thumb/0/09/Flag_of_South_Korea.svg/35px-Flag_of_South_Korea.svg.png 1.5x, //upload.wikimedia.org/wikipedia/commons/thumb/0/09/Flag_of_South_Korea.svg/45px-Flag_of_South_Korea.svg.png 2x" data-file-width="900" data-file-height="600">&nbsp;</span><a href="/wiki/South_Korea" title="South Korea">South Korea</a></span></td>
+               <td>official, in Jeju Island
+               </td>
+            </tr>
+         </tbody>
+      </table>
+   </body>
+</html>


### PR DESCRIPTION
Unnecessary rowspan caused nil pointer exception when populating table values. Instead of initializing the table before parsing/populating, the table rows are initialized during parsing/populating to account for every row/col span.

The resulting json in this issue will have an extra row that does not match what is actually on the page. I think this is ok for now. We should assume that the table is properly formatted. If resulting json does not look right, the wiki table should be inspected.