### PR TITLE
Parse tables concurrently

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,14 +19,9 @@ test:
 
 deploy:
 	docker build -t wikitable-api .
-	docker run --name wikitable-api-container -p 8080:8080 -e PORT=8080 wikitable-api
-
-down:
-	docker stop wikitable-api-container
-	docker rm wikitable-api-container
+	docker run --rm -p 8080:8080 -e PORT=8080 wikitable-api
 
 cover-profile:
-
 	go test -coverprofile=coverage.out ./...
 	go tool cover -html=coverage.out
 	rm -f coverage.out

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -14,7 +14,7 @@ import (
 )
 
 func main() {
-	errCh := make(chan error)
+	errCh := make(chan error, 1)
 
 	lis, err := net.Listen("tcp", ":2000")
 	if err != nil {
@@ -65,11 +65,4 @@ func setupHTTPMux(rMux *runtime.ServeMux) *http.ServeMux {
 
 func serveSwagger(w http.ResponseWriter, r *http.Request) {
 	http.ServeFile(w, r, "swagger/apidocs.swagger.json")
-}
-
-func corsMW(handlerFunc http.HandlerFunc) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		handlerFunc(w, r)
-	}
 }

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -21,10 +21,12 @@ func TestMain(m *testing.M) {
 
 func Test_GetTables(t *testing.T) {
 	tests := []struct {
+		Name                   string
 		TablesRequest          *pb.GetTablesRequest
 		ExepctedTablesResponse *pb.GetTablesResponse
 	}{
 		{
+			"table1",
 			&pb.GetTablesRequest{
 				Page: "table1",
 				N:    []string{},
@@ -82,6 +84,7 @@ func Test_GetTables(t *testing.T) {
 			},
 		},
 		{
+			"table1_n=0",
 			&pb.GetTablesRequest{
 				Page: "table1",
 				N:    []string{"0"},
@@ -139,6 +142,7 @@ func Test_GetTables(t *testing.T) {
 			},
 		},
 		{
+			"table1_lang=cs",
 			&pb.GetTablesRequest{
 				Page: "table1",
 				N:    []string{},
@@ -197,6 +201,7 @@ func Test_GetTables(t *testing.T) {
 			},
 		},
 		{
+			"issue1",
 			&pb.GetTablesRequest{
 				Page: "issue_1",
 				N:    []string{},
@@ -304,18 +309,22 @@ func Test_GetTables(t *testing.T) {
 	svc := &Service{}
 
 	for _, test := range tests {
-		tables, err := svc.GetTables(context.Background(), test.TablesRequest)
-		if err != nil {
-			t.Fatal(err)
-		}
+		t.Run(test.Name, func(t *testing.T) {
+			tables, err := svc.GetTables(context.Background(), test.TablesRequest)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-		if !reflect.DeepEqual(tables, test.ExepctedTablesResponse) {
-			t.Log("expected:")
-			print(test.ExepctedTablesResponse.Tables[0])
-			t.Log("got:")
-			print(tables.Tables[0])
-			t.Errorf("expected %v, got %v", test.ExepctedTablesResponse.Tables[0], tables.Tables[0])
-		}
+			if !reflect.DeepEqual(tables, test.ExepctedTablesResponse) {
+				//t.Log("expected:")
+				//print(test.ExepctedTablesResponse.Tables[0])
+				//t.Logf("%v", test.ExepctedTablesResponse.Tables)
+				//t.Log("got:")
+				//print(tables.Tables[0])
+				//t.Logf("%v", tables)
+				t.Errorf("expected %v, got %v", test.ExepctedTablesResponse.Tables[0], tables.Tables[0])
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Instead of iterating through each wikiTable one by one and appending them to the response, we can process each wikiTable concurrently and append them to the response at the appropriate index.