### PR TITLE
support slashes in request page

### DIFF
--- a/service/pb/wikitable.proto
+++ b/service/pb/wikitable.proto
@@ -34,7 +34,7 @@ message GetTablesResponse {
 service WikiTable {
     rpc GetTables(GetTablesRequest) returns (GetTablesResponse) {
         option (google.api.http) = {
-            get: "/api/v1/page/{page}"
+            get: "/api/v1/page/{page=**}"
         };
     }
 }

--- a/service/service.go
+++ b/service/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"sync"
@@ -188,7 +189,7 @@ func getDocument(req *pb.GetTablesRequest) (*goquery.Document, error) {
 		lang = req.Lang
 	}
 
-	resp, err := http.Get(fmt.Sprintf("https://%s.%s/%s", lang, baseURL, req.Page))
+	resp, err := http.Get(fmt.Sprintf("https://%s.%s/%s", lang, baseURL, url.QueryEscape(req.Page)))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
https://de.wikipedia.org/wiki/Sido/Diskografie returns not found. Need to wildcard the request page and escape the request page so it's safe for URL query.