### PR TITLE
use errgroup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/golang/protobuf v1.4.2
 	github.com/grpc-ecosystem/grpc-gateway v1.14.6
 	github.com/jarcoal/httpmock v1.0.5
+	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 	google.golang.org/genproto v0.0.0-20200513103714-09dca8ec2884
 	google.golang.org/grpc v1.29.1
 	google.golang.org/protobuf v1.23.0


### PR DESCRIPTION
golang.org/x/sync/errgroup package handles the things I was doing manually. Use this package for more hardened code and reduce complexity.