### PR TITLE
Handle Rest API response not OK

### DIFF
--- a/service/service_test.go
+++ b/service/service_test.go
@@ -1,9 +1,11 @@
 package service
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"os"
 	"reflect"
@@ -349,6 +351,10 @@ func Test_GetTables_Error(t *testing.T) {
 			"table1",
 			[]string{"x"},
 		},
+		{
+			"httpError",
+			[]string{},
+		},
 	}
 
 	svc := &Service{}
@@ -372,35 +378,48 @@ func startMocks() {
 	httpmock.RegisterResponder("GET", fmt.Sprintf("https://en.%s/%s", baseURL, "table1"),
 		func(*http.Request) (*http.Response, error) {
 			return &http.Response{
-				Body: getRespBody("table1.html"),
+				Body:       getRespBody("table1.html"),
+				StatusCode: http.StatusOK,
 			}, nil
 		})
 
 	httpmock.RegisterResponder("GET", fmt.Sprintf("https://en.%s/%s", baseURL, "issue_1"),
 		func(*http.Request) (*http.Response, error) {
 			return &http.Response{
-				Body: getRespBody("issue_1.html"),
+				Body:       getRespBody("issue_1.html"),
+				StatusCode: http.StatusOK,
 			}, nil
 		})
 
 	httpmock.RegisterResponder("GET", fmt.Sprintf("https://cs.%s/%s", baseURL, "table1"),
 		func(*http.Request) (*http.Response, error) {
 			return &http.Response{
-				Body: getRespBody("table1.html"),
+				Body:       getRespBody("table1.html"),
+				StatusCode: http.StatusOK,
 			}, nil
 		})
 
 	httpmock.RegisterResponder("GET", fmt.Sprintf("https://en.%s/%s", baseURL, "colspanError"),
 		func(*http.Request) (*http.Response, error) {
 			return &http.Response{
-				Body: getRespBody("colspanError.html"),
+				Body:       getRespBody("colspanError.html"),
+				StatusCode: http.StatusOK,
 			}, nil
 		})
 
 	httpmock.RegisterResponder("GET", fmt.Sprintf("https://en.%s/%s", baseURL, "rowspanError"),
 		func(*http.Request) (*http.Response, error) {
 			return &http.Response{
-				Body: getRespBody("rowspanError.html"),
+				Body:       getRespBody("rowspanError.html"),
+				StatusCode: http.StatusOK,
+			}, nil
+		})
+
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://en.%s/%s", baseURL, "httpError"),
+		func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				Body:       ioutil.NopCloser(&bytes.Buffer{}),
+				StatusCode: http.StatusRequestEntityTooLarge,
 			}, nil
 		})
 }


### PR DESCRIPTION
https://en.wikipedia.org/api/rest_v1/page/html/List_of_airline_codes returns status 413 (payload too large). Nothing I can do about this since this is the response from Wikipedia's Rest API but the app response is "{}" indicating that the call was successful and that there are no tables on the page. There is a table on the page and it's very large and Wikipedia doesn't want to return it. 

Check the http error code and if it's not 200/OK, return an error with the status code.