### PR TITLE
Don't return resp.Statuscode if http.Get returns an error

### DIFF
--- a/service/grpc.go
+++ b/service/grpc.go
@@ -71,11 +71,9 @@ func getDocument(req *pb.GetTablesRequest, get func(string) (*http.Response, err
 		lang = req.Lang
 	}
 
-	url := fmt.Sprintf("https://%s.%s/%s", lang, baseURL, url.QueryEscape(req.Page))
-
-	resp, err := get(url)
+	resp, err := get(fmt.Sprintf("https://%s.%s/%s", lang, baseURL, url.QueryEscape(req.Page)))
 	if err != nil {
-		return nil, resp.StatusCode, err
+		return nil, 0, err
 	}
 	defer resp.Body.Close()
 

--- a/service/run_test.go
+++ b/service/run_test.go
@@ -420,9 +420,7 @@ func TestRunError(t *testing.T) {
 			[]string{"x"},
 			Config{
 				HttpGet: func(string) (*http.Response, error) {
-					return &http.Response{
-						Body: ioutil.NopCloser(&bytes.Buffer{}),
-					}, errors.New("error")
+					return nil, errors.New("error")
 				},
 				HttpSvr: &http.Server{
 					Addr: fmt.Sprintf(":%s", "8080"),


### PR DESCRIPTION
An invalid lang can cause an http request timeout:

`Get "https://pt-br.wikipedia.org/api/rest_v1/page/html/Lista_de_jogos_eletr%C3%B4nicos_mais_vendidos": dial tcp 92.242.140.21:443: i/o timeout`

The http response will be nil so returning the resp.Statuscode will cause a nil pointer panic. If there is an error in calling http.Get, just return 0 for the status code.

