### PR TITLE
handle data-sort-value in span text

### DIFF
--- a/internal/service/parse.go
+++ b/internal/service/parse.go
@@ -18,7 +18,7 @@ type parseTableError struct {
 }
 
 func (e *parseTableError) Error() string {
-	return ""
+	return e.err.Error()
 }
 
 func parseTables(ctx context.Context, wikiTableSelection *goquery.Selection, tableIndices []int32) (*pb.TablesResponse, error) {
@@ -82,23 +82,33 @@ func parseTable(tableSelection *goquery.Selection, tableIndex int) (*pb.Table, e
 			colSpan := 1
 			// get the rowspan and colspan attributes
 			if attr := s.AttrOr("rowspan", ""); attr != "" {
-				rowSpan, err = strconv.Atoi(attr)
-				if err != nil {
-					ptErr.err = err
-					ptErr.rowNum = rowNum
-					ptErr.cellNum = cellNum
-					ptErr.tableIndex = tableIndex
-					return false
+				if attr != "" {
+					rowSpanTexts := strings.Split(attr, " ")
+					if len(rowSpanTexts) > 0 {
+						rowSpan, err = strconv.Atoi(rowSpanTexts[0])
+						if err != nil {
+							ptErr.err = err
+							ptErr.rowNum = rowNum
+							ptErr.cellNum = cellNum
+							ptErr.tableIndex = tableIndex
+							return false
+						}
+					}
 				}
 			}
 			if attr := s.AttrOr("colspan", ""); attr != "" {
-				colSpan, err = strconv.Atoi(attr)
-				if err != nil {
-					ptErr.err = err
-					ptErr.rowNum = rowNum
-					ptErr.cellNum = cellNum
-					ptErr.tableIndex = tableIndex
-					return false
+				if attr != "" {
+					colSpanTexts := strings.Split(attr, " ")
+					if len(colSpanTexts) > 0 {
+						colSpan, err = strconv.Atoi(colSpanTexts[0])
+						if err != nil {
+							ptErr.err = err
+							ptErr.rowNum = rowNum
+							ptErr.cellNum = cellNum
+							ptErr.tableIndex = tableIndex
+							return false
+						}
+					}
 				}
 			}
 			// loop through the spans and populate table columns

--- a/internal/service/run_test.go
+++ b/internal/service/run_test.go
@@ -268,6 +268,37 @@ func TestRunSuccess(t *testing.T) {
 				},
 			},
 		},
+		{
+			"data-sort-value_in_span",
+			"data-sort-value",
+			[]int32{},
+			"",
+			Config{
+				HTTPGet: func(string) (*http.Response, error) {
+					return &http.Response{
+						Body:       getRespBody("data-sort-value.html"),
+						StatusCode: http.StatusOK,
+					}, nil
+				},
+				HTTPSvr: &http.Server{
+					Addr: fmt.Sprintf(":%s", "8080"),
+				},
+				GrpcSvr:     grpc.NewServer(),
+				signalReady: make(chan struct{}),
+			},
+			[]*pb.Table{
+				{
+					Rows: map[int64]*pb.Row{
+						0: {
+							Columns: map[int64]string{
+								0: "Abu Dhabi, United Arab Emirates",
+								1: "N/A",
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -72,7 +72,7 @@ type wikiApiError struct {
 }
 
 func (e *wikiApiError) Error() string {
-	return ""
+	return e.message
 }
 
 func (s *Service) getWikiAPIResponse(ctx context.Context, page, lang string) (*http.Response, error) {
@@ -81,6 +81,7 @@ func (s *Service) getWikiAPIResponse(ctx context.Context, page, lang string) (*h
 		return nil, status.Error(codes.Internal, fmt.Sprintf("failed to make http request to the wikipedia API: %v", err))
 	}
 	if resp.StatusCode != http.StatusOK {
+		defer resp.Body.Close()
 		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
 			return nil, &wikiApiError{statusCode: resp.StatusCode, page: page, message: fmt.Sprintf("failed to read wikipedia API response body: %v", err)}

--- a/internal/service/status_errors.go
+++ b/internal/service/status_errors.go
@@ -14,7 +14,7 @@ func wikiAPIStatusErr(apiErr *wikiApiError) error {
 	st := status.New(codes.Internal, apiErr.message)
 	st, err := st.WithDetails(&errdetails.ErrorInfo{
 		Domain: "wikipedia.org/api/rest_v1/#",
-		Reason: fmt.Sprintf("expected response status 200/OK from the wikipedia API, got something else"),
+		Reason: fmt.Sprintf("expected response status 200/OK from the wikipedia API, got %d/%s", apiErr.statusCode, http.StatusText(apiErr.statusCode)),
 		Metadata: map[string]string{
 			"ResponseStatusCode": strconv.Itoa(apiErr.statusCode),
 			"ResponseStatusText": http.StatusText(apiErr.statusCode),
@@ -34,8 +34,8 @@ func tableParseStatusErr(ptErr *parseTableError) error {
 		Reason: "something unexpected was encountered while parsing tables",
 		Metadata: map[string]string{
 			"TableIndex": strconv.Itoa(ptErr.tableIndex),
-			"RowNumber":  strconv.Itoa(ptErr.rowNum),
-			"CellNumber": strconv.Itoa(ptErr.cellNum),
+			"RowIndex":   strconv.Itoa(ptErr.rowNum),
+			"CellIndex":  strconv.Itoa(ptErr.cellNum),
 		},
 	})
 	if err != nil {

--- a/internal/service/testdata/data-sort-value.html
+++ b/internal/service/testdata/data-sort-value.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<body>
+    <table class="wikitable">
+        <tbody>
+            <tr>
+                <td><a href="/wiki/Abu_Dhabi" title="Abu Dhabi">Abu Dhabi</a>, United Arab Emirates
+                </td>
+                <td rowspan="1 data-sort-value="
+                    style="background: #ececec; color: #2C2C2C; vertical-align: middle; text-align: center;"
+                    class="table-na">N/A
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</body>
+</html>


### PR DESCRIPTION
List_of_UFC_events has rowspans with the form `rowspan="1 data-sort-value="`. This span value fails to be converted to an integer. Need to split the span values by spaces and convert the first value.

Also fixed what I think is a memory leak by closing the wikipedia API response body on non-200 responses. 