### PR TITLE
Support User-Agent header

### DIFF
--- a/internal/entrypoint/entrypoint_test.go
+++ b/internal/entrypoint/entrypoint_test.go
@@ -39,10 +39,17 @@ func TestAPI(t *testing.T) {
 		case "/api/rest_v1/page/html/StatusRequestEntityTooLarge":
 			w.WriteHeader(http.StatusRequestEntityTooLarge)
 			w.Write([]byte("StatusRequestEntityTooLarge"))
+		case "/api/rest_v1/page/html/UserAgent":
+			got := r.Header.Get("User-Agent")
+			want := "test@mail.com"
+			if want != got {
+				t.Errorf("want %s, got %s", want, got)
+			}
 		default:
 			t.Fatalf("path %s not supported", r.URL.Path)
 		}
 	}))
+	defer ts.Close()
 
 	go Run(Config{
 		Port:    PORT,
@@ -149,6 +156,19 @@ func TestAPI(t *testing.T) {
 
 			if !reflect.DeepEqual(want, got) {
 				t.Errorf("want %v\n got %v", want, got)
+			}
+		})
+
+		t.Run("UserAgent", func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://localhost:%s/api/UserAgent", PORT), nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			req.Header.Add("User-Agent", "test@mail.com")
+
+			_, err = http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatal(err)
 			}
 		})
 	})

--- a/internal/entrypoint/static/dist/openapi.yaml
+++ b/internal/entrypoint/static/dist/openapi.yaml
@@ -7,6 +7,7 @@ info:
 
     ### Notes
     - Tables with the HTML class `wikitable`, `standard`, or `toccolours` are returned
+    - If you are making automated requests, set a unique `User-Agent` header with an email address or URL contact page per the [Wikimedia REST API](https://en.wikipedia.org/api/rest_v1/)
 
     ### Examples:
     [https://www.wikitable2json.com/api/Arhaan_Khan](https://www.wikitable2json.com/api/Arhaan_Khan)

--- a/internal/server/data/wikipedia_api.go
+++ b/internal/server/data/wikipedia_api.go
@@ -11,14 +11,18 @@ import (
 	"github.com/atye/wikitable-api/internal/status"
 )
 
-type WikiClient struct {
-	client   *http.Client
-	endpoint string
-}
+const (
+	defaultUserAgent = "Go-http-client/1.1"
+)
 
 var (
 	BaseURL = "https://%s.wikipedia.org/api/rest_v1/page/html/%s"
 )
+
+type WikiClient struct {
+	client   *http.Client
+	endpoint string
+}
 
 func NewWikiClient(endpoint string) WikiClient {
 	return WikiClient{
@@ -27,7 +31,7 @@ func NewWikiClient(endpoint string) WikiClient {
 	}
 }
 
-func (c WikiClient) GetPageData(ctx context.Context, page, lang string) (io.ReadCloser, error) {
+func (c WikiClient) GetPageData(ctx context.Context, page, lang, userAgent string) (io.ReadCloser, error) {
 	addr, err := buildURL(c.endpoint, page, lang)
 	if err != nil {
 		return nil, status.NewStatus(err.Error(), http.StatusInternalServerError)
@@ -36,6 +40,10 @@ func (c WikiClient) GetPageData(ctx context.Context, page, lang string) (io.Read
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, addr, nil)
 	if err != nil {
 		return nil, status.NewStatus(err.Error(), http.StatusInternalServerError)
+	}
+
+	if userAgent != defaultUserAgent {
+		req.Header.Add("User-Agent", userAgent)
 	}
 
 	resp, err := c.client.Do(req)

--- a/internal/server/data/wikipedia_api.go
+++ b/internal/server/data/wikipedia_api.go
@@ -11,18 +11,14 @@ import (
 	"github.com/atye/wikitable-api/internal/status"
 )
 
-const (
-	defaultUserAgent = "Go-http-client/1.1"
-)
-
-var (
-	BaseURL = "https://%s.wikipedia.org/api/rest_v1/page/html/%s"
-)
-
 type WikiClient struct {
 	client   *http.Client
 	endpoint string
 }
+
+var (
+	BaseURL = "https://%s.wikipedia.org/api/rest_v1/page/html/%s"
+)
 
 func NewWikiClient(endpoint string) WikiClient {
 	return WikiClient{
@@ -42,7 +38,7 @@ func (c WikiClient) GetPageData(ctx context.Context, page, lang, userAgent strin
 		return nil, status.NewStatus(err.Error(), http.StatusInternalServerError)
 	}
 
-	if userAgent != defaultUserAgent {
+	if userAgent != "" {
 		req.Header.Add("User-Agent", userAgent)
 	}
 

--- a/internal/server/data/wikipedia_api_test.go
+++ b/internal/server/data/wikipedia_api_test.go
@@ -26,7 +26,7 @@ func TestWikiClient(t *testing.T) {
 
 		sut := NewWikiClient(ts.URL)
 
-		r, err := sut.GetPageData(context.Background(), "test", "en")
+		r, err := sut.GetPageData(context.Background(), "test", "en", "")
 		if err != nil {
 			t.Errorf("expected nil error, got %v", err)
 		}
@@ -57,7 +57,7 @@ func TestWikiClient(t *testing.T) {
 
 		sut := NewWikiClient(ts.URL)
 
-		_, got := sut.GetPageData(context.Background(), "test", "en")
+		_, got := sut.GetPageData(context.Background(), "test", "en", "")
 
 		want := status.Status{
 			Message: "error",
@@ -99,7 +99,7 @@ func TestWikiClient(t *testing.T) {
 			}
 
 			if tc.want != got {
-				t.Errorf("expeted %v, got %v", tc.want, got)
+				t.Errorf("want %v, got %v", tc.want, got)
 			}
 		}
 	})

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -19,7 +19,7 @@ const (
 )
 
 type WikiAPI interface {
-	GetPageData(ctx context.Context, page, lang, userAgnet string) (io.ReadCloser, error)
+	GetPageData(ctx context.Context, page, lang, userAgent string) (io.ReadCloser, error)
 }
 
 type Server struct {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -19,7 +19,7 @@ const (
 )
 
 type WikiAPI interface {
-	GetPageData(ctx context.Context, page, lang string) (io.ReadCloser, error)
+	GetPageData(ctx context.Context, page, lang, userAgnet string) (io.ReadCloser, error)
 }
 
 type Server struct {
@@ -45,7 +45,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	reader, err := s.wiki.GetPageData(r.Context(), page, lang)
+	reader, err := s.wiki.GetPageData(r.Context(), page, lang, r.Header.Get("User-Agent"))
 	if err != nil {
 		writeError(w, err)
 		return


### PR DESCRIPTION
Per https://en.wikipedia.org/api/rest_v1/, the `User-Agent` header should be set. This adds support for that but I am not requiring it.